### PR TITLE
feat: update unified video metadata

### DIFF
--- a/bilidownload/proxy/__init__.py
+++ b/bilidownload/proxy/__init__.py
@@ -1,6 +1,10 @@
 """
 Bilibili API proxies module
 """
+from .constants import (
+    PGC_AVAILABLE_EPISODE_STATUS_CODE,
+    PUGV_AVAILABLE_EPISODE_STATUS_CODE
+)
 from .proxy_service import ProxyService
 from .schemes import (
     GetBangumiDetailResponse,

--- a/bilidownload/proxy/constants.py
+++ b/bilidownload/proxy/constants.py
@@ -16,3 +16,7 @@ REQUEST_WEB_PUBLIC_KEY_URL = \
     'https://passport.bilibili.com/x/passport-login/web/key'
 REQUEST_WEB_SPI_URL = 'https://api.bilibili.com/x/frontend/finger/spi'
 REQUEST_WEB_USER_INFO_URL = 'https://api.bilibili.com/x/web-interface/nav'
+
+
+PGC_AVAILABLE_EPISODE_STATUS_CODE = 2  # 13 is not available
+PUGV_AVAILABLE_EPISODE_STATUS_CODE = 1  # 2 is not available

--- a/bilidownload/proxy/schemes/bangumi.py
+++ b/bilidownload/proxy/schemes/bangumi.py
@@ -219,7 +219,7 @@ class BangumiSectionItemEpisodeItemData(BangumiEpisodeItemData):
     icon_font: BangumiSectionItemEpisodeItemIconFontData
     is_view_hide: bool
     showDrmLoginDialog: bool
-    skip: BangumiSectionItemEpisodeItemSkipData
+    skip: Optional[BangumiSectionItemEpisodeItemSkipData] = None
     stat: BangumiSectionItemEpisodeItemStatData
     stat_for_unity: BangumiSectionItemEpisodeItemStatForUnityData
 

--- a/bilidownload/video_service.py
+++ b/bilidownload/video_service.py
@@ -293,6 +293,12 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
         ]
 
     @classmethod
+    def _format_video_page_title(cls, title: str, long_title: str) -> str:
+        if all([title, long_title]):
+            return f'{title} {long_title}'
+        return title if title else long_title
+
+    @classmethod
     def _parse_work_pages(
         cls,
         dm: GetBangumiDetailResponse
@@ -304,7 +310,7 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                 bvid=item.bvid,
                 epid=item.id_field,
                 cid=item.cid,
-                title=item.long_title,
+                title=cls._format_video_page_title(item.title, item.long_title),
                 badge_text=item.badge_info.text,
                 is_available=True if item.status == PGC_AVAILABLE_EPISODE_STATUS_CODE else False
             ) for item in pages
@@ -319,7 +325,7 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                         bvid=episode.bvid,
                         epid=episode.ep_id,
                         cid=episode.cid,
-                        title=episode.title,
+                        title=cls._format_video_page_title(episode.title, episode.long_title),
                         badge_text=episode.badge_info.text,
                         is_available=True if episode.status == 2 else False
                     )

--- a/bilidownload/video_service.py
+++ b/bilidownload/video_service.py
@@ -75,6 +75,7 @@ class VideoPageLiteItemData(BaseModel):
     epid: Optional[int] = None
     cid: int                    # cid of this page
     title: str                  # Title of this page
+    badge_text: str
     is_available: bool
 
 
@@ -209,6 +210,7 @@ class CommonVideoMetaParser(AbstractVideoMetaParser):
                 bvid=dm.data.bvid,
                 cid=item.cid,
                 title=item.part,
+                badge_text='',
                 is_available=True
             ) for item in pages
         ]
@@ -303,6 +305,7 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                 epid=item.id_field,
                 cid=item.cid,
                 title=item.long_title,
+                badge_text=item.badge_info.text,
                 is_available=True if item.status == PGC_AVAILABLE_EPISODE_STATUS_CODE else False
             ) for item in pages
         ]
@@ -317,6 +320,7 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                         epid=episode.ep_id,
                         cid=episode.cid,
                         title=episode.title,
+                        badge_text=episode.badge_info.text,
                         is_available=True if episode.status == 2 else False
                     )
                 )
@@ -417,6 +421,7 @@ class CheeseVideoMetaParser(AbstractVideoMetaParser):
                 epid=item.id_field,
                 cid=item.cid,
                 title=item.title,
+                badge_text='',
                 is_available=True if item.status == PUGV_AVAILABLE_EPISODE_STATUS_CODE else False
             ) for item in pages
         ]

--- a/bilidownload/video_service.py
+++ b/bilidownload/video_service.py
@@ -57,9 +57,6 @@ VIDEO_TYPE_MAPPING = {
 DEFAULT_STAFF_TITLE = 'UP主'
 
 
-GET_VIDEO_INFO_FUNC_TEMPLATE = '_get_{video_type}_video_info'
-
-
 class VideoMetaStaffItem(BaseModel):
 
     avatar_url: str  # Profile icon's source URL
@@ -144,20 +141,6 @@ def register_parser(video_type: VideoType):
 class CommonVideoMetaParser(AbstractVideoMetaParser):
 
     @classmethod
-    def _parse_work_staff(cls, dm: GetVideoInfoResponse) -> List[VideoMetaStaffItem]:
-        work_staff = dm.data.staff
-        if work_staff is None:
-            work_staff = [dm.data.owner]
-        return [
-            VideoMetaStaffItem(
-                avatar_url=item.face,
-                mid=item.mid,
-                name=item.name,
-                title=item.title if hasattr(item, 'title') else DEFAULT_STAFF_TITLE
-            ) for item in work_staff
-        ]
-
-    @classmethod
     def _get_video_info(cls, url: str, session_data: Optional[str] = None) -> GetVideoInfoResponse:
         params = {}
         aid = cls._get_aid(url)
@@ -218,6 +201,20 @@ class CommonVideoMetaParser(AbstractVideoMetaParser):
         ]
 
     @classmethod
+    def _parse_work_staff(cls, dm: GetVideoInfoResponse) -> List[VideoMetaStaffItem]:
+        work_staff = dm.data.staff
+        if work_staff is None:
+            work_staff = [dm.data.owner]
+        return [
+            VideoMetaStaffItem(
+                avatar_url=item.face,
+                mid=item.mid,
+                name=item.name,
+                title=item.title if hasattr(item, 'title') else DEFAULT_STAFF_TITLE
+            ) for item in work_staff
+        ]
+
+    @classmethod
     def get_video_meta(cls, url: str, session_data: Optional[str] = None) -> VideoMetaModel:
         video_info = cls._get_video_info(url, session_data)
         video_stream_meta = cls._get_video_stream_meta(
@@ -239,6 +236,12 @@ class CommonVideoMetaParser(AbstractVideoMetaParser):
 
 @register_parser(VideoType.BANGUMI)
 class BangumiVideoMetaParser(AbstractVideoMetaParser):
+
+    @classmethod
+    def _format_video_page_title(cls, title: str, long_title: str) -> str:
+        if all([title, long_title]):
+            return f'{title} {long_title}'
+        return title if title else long_title
 
     @classmethod
     def _get_video_info(
@@ -267,21 +270,6 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
         return res_dm
 
     @classmethod
-    def _parse_work_staff(
-        cls,
-        dm: GetBangumiDetailResponse
-    ) -> List[VideoMetaStaffItem]:
-        work_staff = [dm.result.up_info]
-        return [
-            VideoMetaStaffItem(
-                avatar_url=item.avatar,
-                mid=item.mid,
-                name=item.uname,
-                title=DEFAULT_STAFF_TITLE
-            ) for item in work_staff
-        ]
-
-    @classmethod
     def _parse_work_formats(
         cls,
         dm: GetBangumiStreamMetaResponse
@@ -293,12 +281,6 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                 new_description=item.new_description
             ) for item in work_formats
         ]
-
-    @classmethod
-    def _format_video_page_title(cls, title: str, long_title: str) -> str:
-        if all([title, long_title]):
-            return f'{title} {long_title}'
-        return title if title else long_title
 
     @classmethod
     def _parse_work_pages(
@@ -335,6 +317,21 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                     )
                 )
         return result
+
+    @classmethod
+    def _parse_work_staff(
+        cls,
+        dm: GetBangumiDetailResponse
+    ) -> List[VideoMetaStaffItem]:
+        work_staff = [dm.result.up_info]
+        return [
+            VideoMetaStaffItem(
+                avatar_url=item.avatar,
+                mid=item.mid,
+                name=item.uname,
+                title=DEFAULT_STAFF_TITLE
+            ) for item in work_staff
+        ]
 
     @classmethod
     def get_video_meta(cls, url: str, session_data: Optional[str] = None) -> VideoMetaModel:
@@ -392,21 +389,6 @@ class CheeseVideoMetaParser(AbstractVideoMetaParser):
         return res_dm
 
     @classmethod
-    def _parse_work_staff(
-        cls,
-        dm: GetCheeseDetailResponse
-    ) -> List[VideoMetaStaffItem]:
-        work_staff = [dm.data.up_info]
-        return [
-            VideoMetaStaffItem(
-                avatar_url=item.avatar,
-                mid=item.mid,
-                name=item.uname,
-                title=DEFAULT_STAFF_TITLE
-            ) for item in work_staff
-        ]
-
-    @classmethod
     def _parse_work_formats(
         cls,
         dm: GetCheeseStreamMetaResponse
@@ -435,6 +417,21 @@ class CheeseVideoMetaParser(AbstractVideoMetaParser):
                 is_available=True if item.status == PUGV_AVAILABLE_EPISODE_STATUS_CODE else False,
                 duration=item.duration
             ) for item in pages
+        ]
+
+    @classmethod
+    def _parse_work_staff(
+        cls,
+        dm: GetCheeseDetailResponse
+    ) -> List[VideoMetaStaffItem]:
+        work_staff = [dm.data.up_info]
+        return [
+            VideoMetaStaffItem(
+                avatar_url=item.avatar,
+                mid=item.mid,
+                name=item.uname,
+                title=DEFAULT_STAFF_TITLE
+            ) for item in work_staff
         ]
 
     @classmethod

--- a/bilidownload/video_service.py
+++ b/bilidownload/video_service.py
@@ -77,6 +77,7 @@ class VideoPageLiteItemData(BaseModel):
     title: str                  # Title of this page
     badge_text: str
     is_available: bool
+    duration: Optional[int]     # unit is second
 
 
 class VideoMetaModel(BaseModel):
@@ -211,7 +212,8 @@ class CommonVideoMetaParser(AbstractVideoMetaParser):
                 cid=item.cid,
                 title=item.part,
                 badge_text='',
-                is_available=True
+                is_available=True,
+                duration=item.duration
             ) for item in pages
         ]
 
@@ -312,7 +314,8 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                 cid=item.cid,
                 title=cls._format_video_page_title(item.title, item.long_title),
                 badge_text=item.badge_info.text,
-                is_available=True if item.status == PGC_AVAILABLE_EPISODE_STATUS_CODE else False
+                is_available=True if item.status == PGC_AVAILABLE_EPISODE_STATUS_CODE else False,
+                duration=None
             ) for item in pages
         ]
 
@@ -327,7 +330,8 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                         cid=episode.cid,
                         title=cls._format_video_page_title(episode.title, episode.long_title),
                         badge_text=episode.badge_info.text,
-                        is_available=True if episode.status == 2 else False
+                        is_available=True if episode.status == 2 else False,
+                        duration=episode.duration // 1000  # source's unit is millisecond
                     )
                 )
         return result
@@ -428,7 +432,8 @@ class CheeseVideoMetaParser(AbstractVideoMetaParser):
                 cid=item.cid,
                 title=item.title,
                 badge_text='',
-                is_available=True if item.status == PUGV_AVAILABLE_EPISODE_STATUS_CODE else False
+                is_available=True if item.status == PUGV_AVAILABLE_EPISODE_STATUS_CODE else False,
+                duration=item.duration
             ) for item in pages
         ]
 

--- a/bilidownload/video_service.py
+++ b/bilidownload/video_service.py
@@ -16,6 +16,8 @@ from .proxy import (
     GetVideoInfoResponse,
     GetVideoStreamMetaResponse,
     ProxyService,
+    PGC_AVAILABLE_EPISODE_STATUS_CODE,
+    PUGV_AVAILABLE_EPISODE_STATUS_CODE,
     VideoStreamMetaLiteSupportFormatItemData
 )
 
@@ -73,6 +75,7 @@ class VideoPageLiteItemData(BaseModel):
     epid: Optional[int] = None
     cid: int                    # cid of this page
     title: str                  # Title of this page
+    is_available: bool
 
 
 class VideoMetaModel(BaseModel):
@@ -205,7 +208,8 @@ class CommonVideoMetaParser(AbstractVideoMetaParser):
                 aid=dm.data.aid,
                 bvid=dm.data.bvid,
                 cid=item.cid,
-                title=item.part
+                title=item.part,
+                is_available=True
             ) for item in pages
         ]
 
@@ -298,7 +302,8 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                 bvid=item.bvid,
                 epid=item.id_field,
                 cid=item.cid,
-                title=item.long_title
+                title=item.long_title,
+                is_available=True if item.status == PGC_AVAILABLE_EPISODE_STATUS_CODE else False
             ) for item in pages
         ]
 
@@ -311,7 +316,8 @@ class BangumiVideoMetaParser(AbstractVideoMetaParser):
                         bvid=episode.bvid,
                         epid=episode.ep_id,
                         cid=episode.cid,
-                        title=episode.title
+                        title=episode.title,
+                        is_available=True if episode.status == 2 else False
                     )
                 )
         return result
@@ -410,7 +416,8 @@ class CheeseVideoMetaParser(AbstractVideoMetaParser):
                 aid=item.aid,
                 epid=item.id_field,
                 cid=item.cid,
-                title=item.title
+                title=item.title,
+                is_available=True if item.status == PUGV_AVAILABLE_EPISODE_STATUS_CODE else False
             ) for item in pages
         ]
 


### PR DESCRIPTION
## Change Summary
Update unified video metadata:
* `work_pages`: add/change part of fields of each item
  * `title`: format the name of `bangumi` video
  * `badge_text`: add the text of video's badge
  * `is_available`: add video availability (boolean)
  * `duration`: add duration of video, which unit is second